### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MPC Tally API Server
 
+[![smithery badge](https://smithery.ai/badge/mpc-tally-api-server)](https://smithery.ai/server/mpc-tally-api-server)
+
 A Model Context Protocol (MCP) server for interacting with the Tally API. This server allows AI agents to fetch information about DAOs, including their governance data, proposals, and metadata.
 
 ## Features
@@ -12,6 +14,15 @@ A Model Context Protocol (MCP) server for interacting with the Tally API. This s
 
 ## Installation
 
+### Installing via Smithery
+
+To install Tally API Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mpc-tally-api-server):
+
+```bash
+npx -y @smithery/cli install mpc-tally-api-server --client claude
+```
+
+### Manual Installation
 ```bash
 # Clone the repository
 git clone https://github.com/yourusername/mpc-tally-api-server.git


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Tally API Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mpc-tally-api-server

Let me know if any tweaks have to be made!